### PR TITLE
chore: 메뉴 접혀서 렌더링 되도록 config 추가

### DIFF
--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -17,4 +17,8 @@ export default {
       },
     };
   },
+  sidebar: {
+    defaultMenuCollapseLevel: 1,
+    toggleButton: true,
+  },
 };


### PR DESCRIPTION
📣 앞으로 많아질 책 지도를 위해 접힌 메뉴로 렌더링 될 수 있도록 config 추가했습니다~

### ✔️ 메뉴 접힌 상태로 초기 렌더링
| AS-IS | TO-BE |
|:--:|:--:|
| <img src="https://github.com/user-attachments/assets/cff7453f-940d-43ad-a3ef-fc48b45136a2" width="200"/> | <img src="https://github.com/user-attachments/assets/761f52c6-9691-4397-b1ab-9e4a4850a9d8" width="200"/> |
 


